### PR TITLE
Adding pwm2 overlay for roc-rk3328-cc

### DIFF
--- a/libre-computer/roc-rk3328-cc/dt/pwm2.dts
+++ b/libre-computer/roc-rk3328-cc/dt/pwm2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "rockchip,rk3328";
+
+        fragment@0 {
+                target = <&pwm2>;
+                __overlay__ {
+                        status = "okay";
+                };
+        };
+};


### PR DESCRIPTION
To add the pwm node to the device tree on the roc-rk3328-cc board run the following commands as the root user: ./install.sh
./ldto enable pwm2
Now pwm should be added to the device tree and /sys/class/pwm/pwmchip0 should appear in the filesystem