### PR TITLE
Add dts for MCP3008 on aml-s905x-cc

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -1,0 +1,26 @@
+
+/*
+ * Device Tree Overlay to enable MCP3008 ADC
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-gxl-gpio.h>
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	fragment@0 {
+		target = <&spicc>;
+		
+		__overlay__ {
+			mcp3008_00: mcp3008@0 {
+				compatible = "mcp3008";
+				reg = <0>;
+				spi-max-frequency = <30000000>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
I added the overlay for the MCP3008 ADC as discussed here:

https://hub.libre.computer/t/problems-accessing-mcp3008-via-spi-invalid-argument/1844

This is my first ever pull request, so please let me know if I've done something wrong or broken etiquette in any way. Git/Github is confusing for a newbie.