### PR TITLE
Add dts for MCP3008 on aml-s905x-cc (revised)

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -17,10 +17,10 @@
 		
 		__overlay__ {
 			mcp3008@0 {
-				status = "okay";
 				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <30000000>;
+				status = "okay";
 			};
 		};
 	};

--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -16,8 +16,8 @@
 		target = <&spicc>;
 		
 		__overlay__ {
-			status = "okay";
 			mcp3008@0 {
+				status = "okay";
 				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <30000000>;

--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -1,0 +1,26 @@
+
+/*
+ * Device Tree Overlay to enable MCP3008 ADC
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-gxl-gpio.h>
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	fragment@0 {
+		target = <&spicc>;
+		
+		__overlay__ {
+			mcp3008_00: mcp3008@0 {
+				compatible = "mcp3008";
+				reg = <0>;
+				spi-max-frequency = <30000000>;
+			};
+		};
+	};
+};

--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -16,8 +16,9 @@
 		target = <&spicc>;
 		
 		__overlay__ {
-			mcp3008_00: mcp3008@0 {
-				compatible = "mcp3008";
+			status = "okay";
+			mcp3008@0 {
+				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <30000000>;
 			};


### PR DESCRIPTION
Adds the overlay for the MCP3008 ADC, including the changes advised from the previous pull request:


[https://github.com/libre-computer-project/libretech-wiring-tool/pull/6](https://github.com/libre-computer-project/libretech-wiring-tool/pull/6)
