### PR TITLE
Fix spicc-mcp3008.dts spi-max-frequency

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -17,10 +17,10 @@
 		
 		__overlay__ {
 			mcp3008@0 {
-				status = "okay";
 				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <1600000>;
+				status = "okay";
 			};
 		};
 	};

--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp3008.dts
@@ -17,10 +17,10 @@
 		
 		__overlay__ {
 			mcp3008@0 {
+				status = "okay";
 				compatible = "microchip,mcp3008";
 				reg = <0>;
-				spi-max-frequency = <30000000>;
-				status = "okay";
+				spi-max-frequency = <1600000>;
 			};
 		};
 	};


### PR DESCRIPTION
Changed max frequency to 1600000. This greatly reduced erroneous readings.