### PR TITLE
Add support for Seengreat MCP2515 Dual-CH CAN HAT

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp2515-dual-can.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp2515-dual-can.dts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
  *
  * Requires "spicc-cs1" DTS to be loaded first
- * Tested with the "Seengreat Dual-CH CAN HAT" Rev 3.1
+ * Tested with the "Seengreat Dual-CH CAN HAT" Rev 3.1 [https://seengreat.com/dualchcanhat]
  * Interrupts may not be correct for other CAN hats. Adjust accordingly.
  *
  */

--- a/libre-computer/aml-s905x-cc/dt/spicc-mcp2515-dual-can.dts
+++ b/libre-computer/aml-s905x-cc/dt/spicc-mcp2515-dual-can.dts
@@ -1,0 +1,63 @@
+ /*
+ * Copyright (c) Libre Computer
+ * Author: Jeff Karney <jeff.karney@gmail.com>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ *
+ * Requires "spicc-cs1" DTS to be loaded first
+ * Tested with the "Seengreat Dual-CH CAN HAT" Rev 3.1
+ * Interrupts may not be correct for other CAN hats. Adjust accordingly.
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-gxl-gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/meson-gic.h>
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	/* clock for controller */
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			/* external oscillator of mcp2515 on SPI0.0 */
+			osc_can0: osc_can0 {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <16000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spicc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			can0: mcp2515@0 {
+				compatible = "microchip,mcp2515";
+				reg = <0>;
+				clocks = <&osc_can0>;
+				interrupt-parent = <&gpio_intc>;
+				interrupts = <MESON_GIC_GXL_GPIOX_0 IRQ_TYPE_EDGE_FALLING>;
+				spi-max-frequency = <10000000>;
+			};
+
+			can1: mcp2515@1 {
+				compatible = "microchip,mcp2515";
+				reg = <1>;
+				clocks = <&osc_can0>;
+				interrupt-parent = <&gpio_intc>;
+				interrupts = <MESON_GIC_GXL_GPIOX_14 IRQ_TYPE_EDGE_FALLING>;
+				spi-max-frequency = <10000000>;
+			};
+
+		};
+	};
+};
+


### PR DESCRIPTION
This DTS adds support for dual MCP2515 CAN Hats. It has been tested and confirmed working with the "Seengreat Dual-CH CAN HAT" Rev 3.1 [https://seengreat.com/dualchcanhat]