### PR TITLE
 Adding i2c-ao-rv3028 overlay for aml-s905x-cc

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/i2c-ao-rv3028.dts
+++ b/libre-computer/aml-s905x-cc/dt/i2c-ao-rv3028.dts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Mark Bumiller
+ * Author: Mark Bumiller <mark.bumiller@gmail.com>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+
+/*
+ * Overlay aimed to add an RV3028 RTC module on I2C_AO bus, address 0x68.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	fragment@1 {
+		target = <&i2c_AO>;
+		
+		__overlay__ {
+			rtc@52 {
+				compatible = "microcrystal,rv3028";
+				reg = <0x52>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Added support for RV3028 real-time clock.

Tested on latest raspbian image