### PR TITLE
Update Alias i2c-b.dts

### DIFF
--- a/libre-computer/aml-s905x-cc/dt/i2c-b.dts
+++ b/libre-computer/aml-s905x-cc/dt/i2c-b.dts
@@ -20,7 +20,7 @@
 		target-path = "/aliases";
 
 		__overlay__ {
-			i2c2 = "/soc/cbus@c1100000/i2c@87c0";
+			i2c0 = "/soc/cbus@c1100000/i2c@87c0";
 		};
 	};
 


### PR DESCRIPTION
Make alias i2c0 to match the RPi pin 27/28.

This also relates to the use of aliases in device tree, the lowest defined alias gets "i2c-0", no mater what number the lowest alias number is.  to use RPi intended code, this overlay must be loaded as well to get the pin 3 and 5 ic2 to be i2c-1.