### PR TITLE
feat(roc-rk3328,dto): add dt overlay for pps-gpio on pin 7

### DIFF
--- a/libre-computer/roc-rk3328-cc/dt/pps-gpio-j1-28.dts
+++ b/libre-computer/roc-rk3328-cc/dt/pps-gpio-j1-28.dts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Jaime Jackson-Block
+ * Author: Jaime Jackson-Block
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/*
+ * 7 1-28 CLKOUT GPIO1_D4
+ */
+
+/ {
+    compatible = "rockchip,rk3328";
+
+    fragment@0 {
+        target-path = "/";
+
+        __overlay__ {
+            pps_gpio: pps-gpio {
+                compatible = "pps-gpio";
+                pinctrl-names = "default";
+                gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
+                assert-rising-edge;
+                status = "okay";
+            };
+        };
+    };
+};


### PR DESCRIPTION
Enables pps-gpio kernel module to use pin 7 (CLKOUT) as a PPS source on the roc-rk3328-cc.

Tested on Debian 12 Bookworm using a GPS module (GT-U7) supplying a PPS signal on that pin.

![dto-roc-rk3328-cc-pps-gpio-j1-28](https://github.com/libre-computer-project/libretech-wiring-tool/assets/44634577/e04318e9-bdd9-486d-a1f5-836d710983e9)

