### PR TITLE
Add i2c_b.dts for aml-a311d-cc

### DIFF
--- a/libre-computer/aml-a311d-cc/dt/i2c-b.dts
+++ b/libre-computer/aml-a311d-cc/dt/i2c-b.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 BayLibre, SAS.
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+
+/*
+ * Overlay aimed to enable I2C_B on Header 7J1 :
+ * Pins 27 (SDA), 28 (SCL)
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "amlogic,aml-a311d-cc";
+
+	fragment@0 {
+		target-path = "/aliases";
+
+		__overlay__ {
+			i2c0 = "/soc/cbus@c1100000/i2c@87c0";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c_b_pins>;
+
+		__overlay__ {
+			cfg {
+				pins = "GPIOX_17", "GPIOX_18";
+				bias-pull-up;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c_B>;
+		
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c_b_pins>;
+			pinctrl-names = "default";
+		};
+	};
+};


### PR DESCRIPTION
I'm new to dts and overlays. I tried an uneducated guess to enable i2c on the aml-a311d-cc. But I get this dmesg, when trying to enable it with `sudo ldto enable i2c-b`:
```
[296247.866838] OF: resolver: node label 'i2c_b_pins' not found in live devicetree symbols table
[296247.866855] OF: resolver: overlay phandle fixup failed: -22
[296247.866862] create_overlay: Failed to create overlay (err=-22)
```

so ... I'll keep dabbling, but any pointers are welcome. I guess I need to read up more on how to write dts. I only got them to compile. But the Makefile does all the necessary things, so kudos to libre.computer for that!

## Links
- How to write overlays: https://www.digi.com/resources/examples-guides/use-device-tree-overlays-to-patch-your-device-tree
- Hub discussion: https://hub.libre.computer/t/how-to-enable-i2c-on-aml-a311d-cc/3621/2