### PR TITLE
Renegade: added pwm fan on pins 12,13

### DIFF
--- a/libre-computer/roc-rk3328-cc/dt/pwm-2-fan.dts
+++ b/libre-computer/roc-rk3328-cc/dt/pwm-2-fan.dts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Matthew Chandler
+ * Author: Matthew Chandler
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+ 
+/*
+ * Overlay aimed to enable fan on PWM 2 on 40P header Pin 12 with tach on 40P header Pin 11
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/gxbb-clkc.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/*
+ * 11 TPIRQ GPIO2_C4
+ */
+
+/ {
+	compatible = "libretech,roc-rk3328-cc", "rockchip,rk3328";
+	
+	fragment@0 {
+		target = <&i2s1_sdio1>;
+		__overlay__ {
+			mux {
+				bias-pull-up;
+			};
+		};
+	};
+	
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			fan0: pwm-fan {
+				compatible = "pwm-fan";
+				pwms = <&pwm2 0 25000 0>;
+				interrupt-parent = <&gpio2>;
+				interrupts = <20 IRQ_TYPE_EDGE_FALLING>;
+				pulses-per-revolution = <2>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Based on the Le Potato implementation at https://github.com/libre-computer-project/libretech-wiring-tool/blob/master/libre-computer/aml-s905x-cc/dt/pwm-a-fan.dts and adapted to the Renegade

This is my first attempt a writing a DTO file, so I welcome any cleanup / fixes that need to be made. In particular I'm not sure I used the best name for pin 11 when enabling the pull-up, and the '20' on the interrupts line is magic to me. The AML version used a symbol from a header, but no such header currently exists for the rockchip boards (as far as I can tell).

I chose pin 11 for the tach arbitrarily (it was the first one that worked). If there's a better pin that can send interrupts and is less likely to interfere with other GPIO uses, let me know, and I can change it.