### PR TITLE
aml-s805x-ac: Add pps-gpio

### DIFF
--- a/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
+++ b/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Da Xue
+ * Author: Da Xue <da@libre.computer>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+ 
+/*
+ * Overlay aimed to create pps-gpio on 7J1 pin 12 (GPIOH_7)
+ * This requires an GPIO to IRQ enabled kernel and will not work without one.
+ * 
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-gxl-gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/amlogic,meson-gxl-gpio-intc.h>
+
+/ {
+	compatible = "libretech,aml-s805x-ac", "amlogic,s805x", "amlogic,meson-gxl";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			pps_gpio: pps-gpio {
+				compatible = "pps-gpio";
+				pinctrl-names = "default";
+				pinctrl-o = <&i2s_out_ao_clk_pins>;
+				gpios = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
+				interrupts = <&gpio_intc IRQID_GPIOH_7 IRQ_TYPE_EDGE_RISING>;
+				assert-rising-edge;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
+++ b/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022 Da Xue
- * Author: Da Xue <da@libre.computer>
+ * Copyright (c) 2024 Peter Rippe
+ * Author: Peter Rippe
  *
  * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
  */

--- a/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
+++ b/libre-computer/aml-s805x-ac/dt/pps-gpio-7j1-12.dts
@@ -9,6 +9,7 @@
  * Overlay aimed to create pps-gpio on 7J1 pin 12 (GPIOH_7)
  * This requires an GPIO to IRQ enabled kernel and will not work without one.
  * 
+ * Note: Level interrupt is more stable on the s805x than rising edge.
  */
 
 /dts-v1/;
@@ -30,8 +31,7 @@
 				pinctrl-names = "default";
 				pinctrl-o = <&i2s_out_ao_clk_pins>;
 				gpios = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
-				interrupts = <&gpio_intc IRQID_GPIOH_7 IRQ_TYPE_EDGE_RISING>;
-				assert-rising-edge;
+				interrupts = <&gpio_intc IRQID_GPIOH_7 IRQ_TYPE_LEVEL_HIGH>;
 				status = "okay";
 			};
 		};


### PR DESCRIPTION
La Frite pps-gpio overlay on pin 12; based on the one for the [aml-s905x-cc](https://github.com/libre-computer-project/libretech-wiring-tool/blob/master/libre-computer/aml-s905x-cc/dt/pps-gpio-7j1-12.dts)